### PR TITLE
emscripten: enable emscripten build support

### DIFF
--- a/crlib/cpuflags.h
+++ b/crlib/cpuflags.h
@@ -45,7 +45,7 @@ private:
 
 #if defined(CR_WINDOWS) && defined(CR_CXX_MSVC)
    __cpuidex (reinterpret_cast <int32_t *> (data), 1, 0);
-#else
+#elif !defined(CR_EMSCRIPTEN)
       __get_cpuid (0x1, &data[eax], &data[ebx], &data[ecx], &data[edx]);
 #endif
       sse3 = !!(data[ecx] & CpuCap::SSE3);
@@ -56,7 +56,7 @@ private:
 
 #if defined(CR_WINDOWS) && defined(CR_CXX_MSVC)
       __cpuidex (reinterpret_cast <int32_t *> (data), 7, 0);
-#else
+#elif !defined(CR_EMSCRIPTEN)
       __get_cpuid (0x7, &data[eax], &data[ebx], &data[ecx], &data[edx]);
 #endif
       avx2 = !!(data[ebx] & CpuCap::AVX2);

--- a/crlib/platform.h
+++ b/crlib/platform.h
@@ -18,6 +18,10 @@ CR_NAMESPACE_BEGIN
 #  define CR_WINDOWS
 #endif
 
+#if defined(__EMSCRIPTEN__)
+#  define CR_EMSCRIPTEN
+#endif
+
 #if defined(__ANDROID__)
 #  define CR_ANDROID
 #endif
@@ -274,6 +278,7 @@ struct Platform : public Singleton <Platform> {
    bool ppc = false;
    bool simd = false;
    bool psvita = false;
+   bool emscripten = false;
 
    char appName[64] = {};
 
@@ -308,6 +313,10 @@ struct Platform : public Singleton <Platform> {
 
 #if defined(CR_ARCH_PPC)
       ppc = true;
+#endif
+
+#if defined(CR_EMSCRIPTEN)
+   	  emscripten = true;
 #endif
 
 #if !defined(CR_DISABLE_SIMD)


### PR DESCRIPTION
Adds support to build yapb bots module with [emscripten](https://emscripten.org) and run in browser.

[Live demo](https://turch.in/cs/index.html)